### PR TITLE
feat: add projectUrl input

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ The scenario illustrated below shows how one can work with providing specific pr
 |**orchestratorApplicationScope**|External application scope|False|"OR.Assets OR.BackgroundTasks OR.Execution OR.Folders OR.Jobs OR.Machines.Read OR.Monitoring OR.Robots.Read OR.Settings.Read OR.TestSets OR.TestSetExecutions OR.TestSetSchedules OR.Users.Read"|
 |**projectVersion**|A valid semver tag version number (without the leading 'v') to set the version of the packages|True||
 |**releaseNotes**|Release notes to be added in the generated .nupkg files|False||
+|**projectUrl**|Project URL for the generated package. Usually associated with the Automation Hub project. If not provided, the repository URL will be used|||
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,9 @@ inputs:
   releaseNotes:
     description: 'Release notes for the package'
     required: false
+  projectUrl:
+    description: 'Project URL for the generated package. Usually associated with the Automation Hub project. If not provided, the repository URL will be used'
+    required: false
 outputs:
   packagesPath:
     description: 'Folder containing the generated packages'
@@ -41,6 +44,20 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - id: set-urls
+      name: Set URLs
+      shell: bash
+      run: |
+        repoUrl="${{ github.server_url }}/${{ github.repository }}"
+        echo "repoUrl=$repoUrl" >> $GITHUB_OUTPUT
+        if [ -z "${{ inputs.projectUrl }}" ]; then
+          echo "projectUrl=$repoUrl" >> $GITHUB_OUTPUT
+          echo "projectUrl: $repoUrl"
+        else
+          echo "projectUrl=${{ inputs.projectUrl }}" >> $GITHUB_OUTPUT
+          echo "projectUrl: ${{ inputs.projectUrl}}"
+        fi
+
     - id: pack
       name: Pack
       shell: bash
@@ -56,8 +73,6 @@ runs:
           projectJsonFiles=$(echo "${{ inputs.projectFilePaths }}" | tr '\r\n' '\n' | sed '/^\s*$/d' | while read -r line; do echo "${{ github.workspace }}/$line"; done)
         fi
 
-        repoUrl="${{ github.server_url }}/${{ github.repository }}"
-
         while IFS= read -r p; do
           echo "::group::uipcli output for packing project: $p"
           uipcli package pack "$p" \
@@ -72,10 +87,11 @@ runs:
             --releaseNotes "${{ inputs.releaseNotes }}" \
             --version "${{ inputs.projectVersion }}" \
             -l en-US \
-            --repositoryUrl "$repoUrl" \
+            --repositoryUrl "${{ steps.set-urls.outputs.repoUrl }}"  \
             --repositoryCommit "${{ github.sha }}" \
             --repositoryBranch "${{ github.ref_name }}" \
-            --repositoryType git
+            --repositoryType git \
+            --projectUrl "${{ steps.set-urls.outputs.projectUrl }}" 
 
           echo "::endgroup::"
 


### PR DESCRIPTION
Add input projectUrl to add project URL to the generated package. Usually associated with the linked Automation Hub project, but if that is not provided a link to the repository is used in its place