### PR TITLE
fix: get actual branch name on pull request

### DIFF
--- a/.github/workflows/uipath-ci.yml
+++ b/.github/workflows/uipath-ci.yml
@@ -25,10 +25,10 @@ jobs:
     runs-on: windows-latest
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       # The UiPath CLI is installed on Runner
-      - uses: Mikael-RnD/setup-uipath@v2
+      - run: dotnet tool install UiPath.CLI.Windows --global
       
       # Run workflow analysis on and pack UiPath projects
       - id: pack
@@ -45,7 +45,7 @@ jobs:
           releaseNotes: 'Initial release'
 
       # Upload packages as build artifacts to be handled by deploy job
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: pack-artifact
           path: ${{ steps.pack.outputs.packagesPath }}
@@ -56,10 +56,10 @@ jobs:
     runs-on: windows-latest
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       # The UiPath CLI is installed on Runner
-      - uses: Mikael-RnD/setup-uipath@v2
+      - run: dotnet tool install UiPath.CLI.Windows --global
       
       # Run workflow analysis on and pack UiPath projects
       - id: pack
@@ -79,7 +79,7 @@ jobs:
           releaseNotes: 'Initial release with file input'
 
       # Upload packages as build artifacts to be handled by deploy job
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: pack-with-file-input
           path: ${{ steps.pack.outputs.packagesPath }}
@@ -90,13 +90,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
-      - name: uipath-setup
-        uses: Mikael-RnD/setup-uipath@v2
+      - run: dotnet tool install UiPath.CLI.Linux --global
 
       - name: setup-dotnet
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
             8.0.x

--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,10 @@ inputs:
   projectUrl:
     description: 'Project URL for the generated package. Usually associated with the Automation Hub project. If not provided, the repository URL will be used'
     required: false
+  traceLevel:
+    description: 'Trace level for the packing process. Possible values: Verbose, Information, Warning, Error'
+    default: "Information"
+    required: false
 outputs:
   packagesPath:
     description: 'Folder containing the generated packages'
@@ -92,7 +96,7 @@ runs:
             --repositoryBranch "${{ github.head_ref || github.ref_name }}" \
             --repositoryType git \
             --projectUrl "${{ steps.set-urls.outputs.projectUrl }}"  \
-            --traceLevel "Warning"
+            --traceLevel "${{ inputs.traceLevel }}"
 
           echo "::endgroup::"
 

--- a/action.yml
+++ b/action.yml
@@ -89,7 +89,7 @@ runs:
             -l en-US \
             --repositoryUrl "${{ steps.set-urls.outputs.repoUrl }}"  \
             --repositoryCommit "${{ github.sha }}" \
-            --repositoryBranch "${{ github.ref_name }}" \
+            --repositoryBranch "${{ github.head_ref || github.ref_name }}" \
             --repositoryType git \
             --projectUrl "${{ steps.set-urls.outputs.projectUrl }}"  \
             --traceLevel "Warning"


### PR DESCRIPTION
Change expression for getting branch name to get the actual branch name when running on pull requests by retrieving head_ref as the main option and falling back to ref_name if that does not exist